### PR TITLE
Update README for setup.sh rename and JetBrains Toolbox removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ubuntu Drivers — Lenovo ThinkPad E14
 
-Shell script to update drivers and selected dev setup steps on a Lenovo ThinkPad E14 running Ubuntu.
+Setup script for drivers and dev tooling on a Lenovo ThinkPad E14 running Ubuntu.
 
 ## What it updates
 
@@ -16,13 +16,12 @@ Shell script to update drivers and selected dev setup steps on a Lenovo ThinkPad
 | 8 | **Userland (Brew)** | `git`, `curl`, `wget`, `vim`, `fish`, `starship`, `gh`, `asdf` |
 | 9 | **Shell + asdf** | Fish config, Starship config, Python 3.10.14, Node.js 24.14.0, aicommits |
 | 10 | **Fonts** | JetBrains Mono latest stable (download at runtime) |
-| 11 | **JetBrains** | JetBrains Toolbox latest stable (download at runtime) |
-| 12 | **Tools** | Zed editor |
-| 13 | **Cleanup** | Remove orphaned packages and stale caches |
-| 14 | **AI Tooling** | Claude Code installer (current user) |
-| 15 | **AI Tooling** | GitHub Copilot CLI installer (current user) |
-| 16 | **Terminal** | Warp latest `.deb` (download via `app.warp.dev/download?package=deb`) |
-| 17 | **Desktop** | Set GNOME wallpaper to `assets/wallpapers/red_distortion_3.jpg` (`zoom`) |
+| 11 | **Tools** | Zed editor |
+| 12 | **Cleanup** | Remove orphaned packages and stale caches |
+| 13 | **AI Tooling** | Claude Code installer (current user) |
+| 14 | **AI Tooling** | GitHub Copilot CLI installer (current user) |
+| 15 | **Terminal** | Warp latest `.deb` (download via `app.warp.dev/download?package=deb`) |
+| 16 | **Desktop** | Set GNOME wallpaper to `assets/wallpapers/red_distortion_3.jpg` (`zoom`) |
 
 ## Hardware
 
@@ -38,7 +37,7 @@ Shell script to update drivers and selected dev setup steps on a Lenovo ThinkPad
 ```bash
 git clone https://github.com/carvalhocaio/ubuntu-drivers.git
 cd ubuntu-drivers
-sudo ./update-drivers.sh
+sudo ./setup.sh
 ```
 
 The script opens an interactive selector in the terminal (steps `1-5` are pre-selected by default):
@@ -55,13 +54,13 @@ If you downloaded the repository as a `.zip` from GitHub, the execute bit **is n
 You need to grant it manually before running:
 
 ```bash
-chmod +x update-drivers.sh
-sudo ./update-drivers.sh
+chmod +x setup.sh
+sudo ./setup.sh
 ```
 
 The script requires root privileges and will prompt for a reboot at the end if one is needed.
 
-Note for step 17 (Wallpaper): this step needs an active graphical login session for the selected user.
+Note for step 16 (Wallpaper): this step needs an active graphical login session for the selected user.
 If no desktop session bus is available yet, the script will skip wallpaper setup and show a warning.
 
 ## Requirements


### PR DESCRIPTION
## Summary

Follow-up to #3 — updates the README to match the script changes already merged.

- Updated all script references from `update-drivers.sh` → `setup.sh`
- Removed step 11 (JetBrains Toolbox) from the step table
- Renumbered steps 12–17 → 11–16
- Updated the wallpaper note from "step 17" → "step 16"
- Tweaked opening description to match the new script name

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzNJUiDVrGhqx4r8ffQjv4)_