### PR TITLE
Add OpenCode and gh CLI steps; remove gh from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Setup script for drivers and dev tooling.
 | 5 | **Security & Firmware** | Kernel, `intel-microcode`, `thermald`, TPM tools, Lenovo firmware via `fwupd` |
 | 6 | **Build + Brew** | `build-essential`, `libssl-dev`, and Homebrew bootstrap/update |
 | 7 | **Docker** | Docker Engine, CLI, containerd, Buildx, Compose plugin |
-| 8 | **Userland (Brew)** | `git`, `curl`, `wget`, `vim`, `fish`, `starship`, `gh`, `asdf` |
+| 8 | **Userland (Brew)** | `git`, `curl`, `wget`, `vim`, `fish`, `starship`, `asdf` |
 | 9 | **Shell + asdf** | Fish config, Starship config, Python 3.10.14, Node.js 24.14.0 |
 | 10 | **Fonts** | JetBrains Mono latest stable (download at runtime) |
 | 11 | **Tools** | Zed (via official install script) |
 | 12 | **Cleanup** | Remove orphaned packages and stale caches |
 | 13 | **AI Tooling** | Claude Code installer (current user) |
-| 14 | **Terminal** | Warp latest `.deb` (download via `app.warp.dev/download?package=deb`) |
-| 15 | **Desktop** | Set GNOME wallpaper to `assets/wallpapers/red_distortion_3.jpg` (`zoom`) |
+| 14 | **AI Tooling** | OpenCode installer (current user) |
+| 15 | **CLI** | gh CLI via official apt repo (`cli.github.com`) |
+| 16 | **Terminal** | Warp latest `.deb` (download via `app.warp.dev/download?package=deb`) |
+| 17 | **Desktop** | Set GNOME wallpaper to `assets/wallpapers/red_distortion_3.jpg` (`zoom`) |
 
 ## Hardware
 
@@ -59,7 +61,7 @@ sudo ./setup.sh
 
 The script requires root privileges and will prompt for a reboot at the end if one is needed.
 
-Note for step 15 (Wallpaper): this step needs an active graphical login session for the selected user.
+Note for step 17 (Wallpaper): this step needs an active graphical login session for the selected user.
 If no desktop session bus is available yet, the script will skip wallpaper setup and show a warning.
 
 ## Requirements

--- a/setup.sh
+++ b/setup.sh
@@ -66,8 +66,10 @@ STEP_TITLE[10]="JetBrains Mono font"
 STEP_TITLE[11]="Zed"
 STEP_TITLE[12]="Cleanup"
 STEP_TITLE[13]="Claude Code"
-STEP_TITLE[14]="Warp Terminal"
-STEP_TITLE[15]="Wallpaper"
+STEP_TITLE[14]="OpenCode"
+STEP_TITLE[15]="gh CLI"
+STEP_TITLE[16]="Warp Terminal"
+STEP_TITLE[17]="Wallpaper"
 
 STEP_DESC[1]="apt update/upgrade"
 STEP_DESC[2]="mesa, intel media, ubuntu-drivers"
@@ -76,14 +78,16 @@ STEP_DESC[4]="dkms, bluez"
 STEP_DESC[5]="kernel, microcode, fwupd, thermald"
 STEP_DESC[6]="build deps + install Homebrew"
 STEP_DESC[7]="docker-ce + compose plugin"
-STEP_DESC[8]="git curl wget vim fish starship gh asdf"
+STEP_DESC[8]="git curl wget vim fish starship asdf"
 STEP_DESC[9]="fish config + python/node via asdf"
 STEP_DESC[10]="download and install latest JetBrains Mono"
 STEP_DESC[11]="install Zed for current user"
 STEP_DESC[12]="apt/brew cleanup"
 STEP_DESC[13]="install Claude Code for current user"
-STEP_DESC[14]="install Warp (.deb)"
-STEP_DESC[15]="set GNOME wallpaper"
+STEP_DESC[14]="install OpenCode for current user"
+STEP_DESC[15]="install gh CLI via official apt repo"
+STEP_DESC[16]="install Warp (.deb)"
+STEP_DESC[17]="set GNOME wallpaper"
 
 run_step() {
   local n="$1"
@@ -216,7 +220,7 @@ EOF
 
 step_8() {
   local pkg
-  for pkg in git curl wget vim fish starship gh asdf; do
+  for pkg in git curl wget vim fish starship asdf; do
     brew_ensure_pkg "$pkg"
   done
 
@@ -327,6 +331,23 @@ step_13() {
 }
 
 step_14() {
+  as_user 'curl -fsSL https://opencode.ai/install | bash'
+  info "OpenCode installed for $REAL_USER"
+}
+
+step_15() {
+  mkdir -p -m 755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    -o /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  apt update
+  apt install -y gh
+  info "gh CLI installed"
+}
+
+step_16() {
   local warp_deb="$TMP_ROOT/warp.deb"
   local warp_pkg="deb"
 
@@ -345,7 +366,7 @@ step_14() {
   info "Warp installed/updated"
 }
 
-step_15() {
+step_17() {
   local wallpaper_path="$SCRIPT_DIR/$WALLPAPER_REL_PATH"
   local wallpaper_uri="file://$wallpaper_path"
   local real_uid
@@ -391,7 +412,7 @@ choose_steps() {
   local key
   local current=1
   local all_selected
-  local -i max_step=15
+  local -i max_step=17
   declare -A selected
 
   for i in $(seq 1 "$max_step"); do
@@ -502,8 +523,9 @@ print_summary() {
   echo "  Starship:   $(brew_run 'starship --version' 2>/dev/null | head -1 || echo 'N/A')"
   echo "  Python:     $(brew_run '$HOME/.asdf/shims/python --version' 2>/dev/null || echo 'N/A')"
   echo "  Node.js:    $(brew_run '$HOME/.asdf/shims/node --version' 2>/dev/null || echo 'N/A')"
-  echo "  gh:         $(brew_run 'gh --version' 2>/dev/null | head -1 || echo 'N/A')"
+  echo "  gh:         $(gh --version 2>/dev/null | head -1 || echo 'N/A')"
   echo "  Claude:     $(as_user 'claude --version' 2>/dev/null | head -1 || echo 'N/A')"
+  echo "  OpenCode:   $(as_user 'opencode --version' 2>/dev/null | head -1 || echo 'N/A')"
   echo "  Warp:       $(warp-terminal --version 2>/dev/null | head -1 || echo 'N/A')"
   echo "  Wallpaper:  $(as_user 'gsettings get org.gnome.desktop.background picture-uri' 2>/dev/null || echo 'N/A')"
   echo "  Zed:        $(as_user 'zed --version' 2>/dev/null | head -1 || echo 'N/A')"


### PR DESCRIPTION
- step 8: remove gh from Homebrew (now installed via official repo)
- step 14: OpenCode (curl -fsSL https://opencode.ai/install | bash)
- step 15: gh CLI via official apt repo (cli.github.com)
- Warp → step 16, Wallpaper → step 17; max_step 15→17
- print_summary: gh via system path, add OpenCode line
- README: updated table and wallpaper step note

https://claude.ai/code/session_01DvFj7NbgmDjU7ridhWCeBx